### PR TITLE
Update copyright notice and improve IWYU regex patterns

### DIFF
--- a/tool/check_file_name_lengths.py
+++ b/tool/check_file_name_lengths.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 """Checks file name lengths
 
-    Copyright (C) 2019-2026 kaoru  https://www.tetengo.org/
+Copyright (C) 2019-2026 kaoru  https://www.tetengo.org/
 """
 
 import os

--- a/tool/filter_iwyuout.py
+++ b/tool/filter_iwyuout.py
@@ -10,7 +10,9 @@ import sys
 
 def main() -> None:
     """The main function."""
-    no_error_pattern: re.Pattern[str] = re.compile(r"has correct #includes/fwd-decls\)$")
+    no_error_pattern: re.Pattern[str] = re.compile(
+        r"has correct #includes/fwd-decls\)$"
+    )
     exit_code: int = 0
     for line in sys.stdin:
         line = line.rstrip("\n")

--- a/tool/filter_iwyuout.py
+++ b/tool/filter_iwyuout.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 """IWYU output filter
 
-    Copyright (C) 2019-2026 kaoru  https://www.tetengo.org/
+Copyright (C) 2019-2026 kaoru  https://www.tetengo.org/
 """
 
 import re

--- a/tool/filter_iwyuout.py
+++ b/tool/filter_iwyuout.py
@@ -10,7 +10,7 @@ import sys
 
 def main() -> None:
     """The main function."""
-    no_error_pattern: re.Pattern[str] = re.compile("has correct #includes/fwd-decls\)$")
+    no_error_pattern: re.Pattern[str] = re.compile(r"has correct #includes/fwd-decls\)$")
     exit_code: int = 0
     for line in sys.stdin:
         line = line.rstrip("\n")

--- a/tool/iwyu_mappings.imp
+++ b/tool/iwyu_mappings.imp
@@ -9,11 +9,13 @@
   { include: ["<ext/new_allocator.h>",  "private", "<cstddef>",     "public"] },
   
   { include: ["@<boost/algorithm/string/.+>",                      "private", "<boost/algorithm/string.hpp>",          "public"] },
+  { include: ["<boost/container/detail/std_fwd.hpp>",              "private", "<utility>",                             "public"] },
   { include: ["<boost/container_hash/extensions.hpp>",             "private", "<boost/container_hash/hash.hpp>",       "public"] },
   { include: ["<boost/detail/basic_pointerbuf.hpp>",               "private", "<boost/lexical_cast.hpp>",              "public"] },
   { include: ["@<boost/format/.+>",                                "private", "<boost/format.hpp>",                    "public"] },
   { include: ["<boost/interprocess/detail/os_file_functions.hpp>", "private", "<boost/interprocess/file_mapping.hpp>", "public"] },
   { include: ["@<boost/lexical_cast/.+>",                          "private", "<boost/lexical_cast.hpp>",              "public"] },
+  { include: ["<boost/move/detail/type_traits.hpp>",               "private", "<utility>",                             "public"] },
   { include: ["@<boost/preprocessor/.+>",                          "private", "<boost/preprocessor.hpp>",              "public"] },
   { include: ["@<boost/program_options/.+>",                       "private", "<boost/program_options.hpp>",           "public"] },
   { include: ["@<boost/uuid/basic_random_generator.hpp>",          "private", "<boost/uuid/random_generator.hpp>",     "public"] },

--- a/tool/list_sources.py
+++ b/tool/list_sources.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 """Lists the source files
 
-    Copyright (C) 2019-2026 kaoru  https://www.tetengo.org/
+Copyright (C) 2019-2026 kaoru  https://www.tetengo.org/
 """
 
 import os.path

--- a/tool/make_precompiled_h.py
+++ b/tool/make_precompiled_h.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 """Makes precompiled.h
-    
-    Copyright (C) 2019-2026 kaoru  https://www.tetengo.org/
+
+Copyright (C) 2019-2026 kaoru  https://www.tetengo.org/
 """
 
 import re


### PR DESCRIPTION
This pull request introduces a new mapping for Boost headers and a minor code style improvement in the IWYU output filtering script.

**IWYU mapping updates:**
* Added a mapping to replace `<boost/container/detail/std_fwd.hpp>` with `<utility>` as a public include.
* Added a mapping to replace `<boost/move/detail/type_traits.hpp>` with `<utility>` as a public include.

**Code style improvements:**
* Reformatted the regular expression in `filter_iwyuout.py` for better readability by splitting it across lines.