### PR TITLE
Ignore IWYU private include warnings and add Boost mappings

### DIFF
--- a/tool/filter_iwyuout.py
+++ b/tool/filter_iwyuout.py
@@ -13,12 +13,17 @@ def main() -> None:
     no_error_pattern: re.Pattern[str] = re.compile(
         r"has correct #includes/fwd-decls\)$"
     )
+    ignorable_warning_pattern: re.Pattern[str] = re.compile(
+        r"warning: no private include name for @headername mapping$"
+    )
     exit_code: int = 0
     for line in sys.stdin:
         line = line.rstrip("\n")
         if len(line) == 0:
             continue
         if no_error_pattern.search(line):
+            continue
+        if ignorable_warning_pattern.search(line):
             continue
         print(line)
         exit_code = 1

--- a/tool/iwyu_mappings.imp
+++ b/tool/iwyu_mappings.imp
@@ -1,6 +1,7 @@
 [
   { include: ["<bits/exception.h>",     "private", "<exception>",   "public"] },
   { include: ["<bits/std_function.h>",  "private", "<functional>",  "public"] },
+  { include: ["<bits/unicode-data.h>",  "private", "<format>",      "public"] },
   { include: ["@<bits/fs_.+>",          "private", "<filesystem>",  "public"] },
   { include: ["<bits/shared_ptr.h>",    "private", "<memory>",      "public"] },
   { include: ["@<bits/stdint-.+>",      "private", "<cstdint>",     "public"] },

--- a/tool/iwyu_mappings.imp
+++ b/tool/iwyu_mappings.imp
@@ -13,6 +13,7 @@
   { include: ["<boost/container/detail/std_fwd.hpp>",              "private", "<utility>",                             "public"] },
   { include: ["<boost/container_hash/extensions.hpp>",             "private", "<boost/container_hash/hash.hpp>",       "public"] },
   { include: ["<boost/detail/basic_pointerbuf.hpp>",               "private", "<boost/lexical_cast.hpp>",              "public"] },
+  { include: ["<boost/endian/detail/order.hpp>",                   "private", "<boost/endian/buffers.hpp>",            "public"] },
   { include: ["@<boost/format/.+>",                                "private", "<boost/format.hpp>",                    "public"] },
   { include: ["<boost/interprocess/detail/os_file_functions.hpp>", "private", "<boost/interprocess/file_mapping.hpp>", "public"] },
   { include: ["@<boost/lexical_cast/.+>",                          "private", "<boost/lexical_cast.hpp>",              "public"] },


### PR DESCRIPTION
This pull request updates the IWYU (Include What You Use) tooling and mappings to improve filtering of ignorable warnings and to add new include mappings for better header management. The main improvements are in how the tool filters output and in expanding the mapping file to handle more header relationships.

Filtering improvements:

* The script `filter_iwyuout.py` now ignores lines matching the warning "no private include name for @headername mapping", reducing noise from known ignorable warnings in the output.

Mapping updates:

* Added a new mapping in `iwyu_mappings.imp` to associate `<bits/unicode-data.h>` (private) with `<format>` (public), ensuring correct header substitution.
* Added a new mapping in `iwyu_mappings.imp` to associate `<boost/endian/detail/order.hpp>` (private) with `<boost/endian/buffers.hpp>` (public), improving Boost header handling.